### PR TITLE
Add AI chat quick action component to user homepage

### DIFF
--- a/src/pages/user/userhomepage/ComponentQuickActionAiChat.tsx
+++ b/src/pages/user/userhomepage/ComponentQuickActionAiChat.tsx
@@ -1,0 +1,141 @@
+import { LucidePlus } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import axiosCustom from '../../../config/axiosCustom';
+
+const chipAction =
+    'inline-flex items-center gap-1 rounded-xl border-2 border-sky-200/70 bg-white/95 px-2 py-1 text-[11px] font-semibold text-sky-800 shadow-sm transition hover:-translate-y-px hover:border-cyan-300 hover:bg-gradient-to-r hover:from-sky-50 hover:to-cyan-50 disabled:opacity-50';
+
+type LastUsedModelState = {
+    loaded: 'true' | 'false' | 'pending';
+    aiModelProvider: 'openrouter' | 'groq' | 'ollama' | 'openai-compatible';
+    aiModelName: string;
+    aiModelOpenAiCompatibleConfigId: string | null;
+};
+
+const defaultLastUsedModelState: LastUsedModelState = {
+    loaded: 'pending',
+    aiModelProvider: 'openrouter',
+    aiModelName: 'openrouter/auto',
+    aiModelOpenAiCompatibleConfigId: null,
+};
+
+let chatRouteChunkPrefetchPromise: Promise<unknown> | null = null;
+
+const prefetchChatRouteChunk = () => {
+    if (!chatRouteChunkPrefetchPromise) {
+        chatRouteChunkPrefetchPromise = import('../features/ChatLlmList/ChatLlmListWrapper.tsx');
+    }
+    return chatRouteChunkPrefetchPromise;
+};
+
+const ComponentQuickActionAiChat = () => {
+    const [isAddThreadLoading, setIsAddThreadLoading] = useState(false);
+    const [isLastUsedModelLoadedObj, setIsLastUsedModelLoadedObj] =
+        useState<LastUsedModelState>(defaultLastUsedModelState);
+
+    const navigate = useNavigate();
+
+    const fetchLastUsedModel = useCallback(async () => {
+        setIsLastUsedModelLoadedObj((prev) => ({ ...prev, loaded: 'pending' }));
+        try {
+            const lastUsedResponse = await axiosCustom.get('/api/chat-llm/threads-crud/lastUsedLlmModel');
+            if (lastUsedResponse.data.model) {
+                setIsLastUsedModelLoadedObj({
+                    loaded: 'true',
+                    aiModelProvider: lastUsedResponse.data.model.aiModelProvider,
+                    aiModelName: lastUsedResponse.data.model.aiModelName,
+                    aiModelOpenAiCompatibleConfigId:
+                        lastUsedResponse.data.model.aiModelOpenAiCompatibleConfigId || null,
+                });
+            } else {
+                setIsLastUsedModelLoadedObj({
+                    ...defaultLastUsedModelState,
+                    loaded: 'true',
+                });
+            }
+        } catch (error) {
+            console.error('Error fetching last used model:', error);
+            setIsLastUsedModelLoadedObj({
+                ...defaultLastUsedModelState,
+                loaded: 'false',
+            });
+        }
+    }, []);
+
+    useEffect(() => {
+        void fetchLastUsedModel();
+        void prefetchChatRouteChunk();
+    }, [fetchLastUsedModel]);
+
+    const addNewThread = async () => {
+        setIsAddThreadLoading(true);
+        try {
+            let modelState = isLastUsedModelLoadedObj;
+
+            if (modelState.loaded === 'pending') {
+                try {
+                    const lastUsedResponse = await axiosCustom.get('/api/chat-llm/threads-crud/lastUsedLlmModel');
+                    if (lastUsedResponse.data.model) {
+                        modelState = {
+                            loaded: 'true',
+                            aiModelProvider: lastUsedResponse.data.model.aiModelProvider,
+                            aiModelName: lastUsedResponse.data.model.aiModelName,
+                            aiModelOpenAiCompatibleConfigId:
+                                lastUsedResponse.data.model.aiModelOpenAiCompatibleConfigId || null,
+                        };
+                    } else {
+                        modelState = {
+                            ...defaultLastUsedModelState,
+                            loaded: 'true',
+                        };
+                    }
+                    setIsLastUsedModelLoadedObj(modelState);
+                } catch (error) {
+                    console.error('Error fetching last used model:', error);
+                    modelState = {
+                        ...defaultLastUsedModelState,
+                        loaded: 'false',
+                    };
+                    setIsLastUsedModelLoadedObj(modelState);
+                }
+            }
+
+            const result = await axiosCustom.post('/api/chat-llm/threads-crud/threadsAdd', {
+                isPersonalContextEnabled: false,
+                isAutoAiContextSelectEnabled: false,
+                aiModelProvider: modelState.aiModelProvider,
+                aiModelName: modelState.aiModelName,
+                aiModelOpenAiCompatibleConfigId: modelState.aiModelOpenAiCompatibleConfigId,
+            });
+
+            const tempThreadId = result?.data?.thread?._id;
+            if (tempThreadId && typeof tempThreadId === 'string') {
+                navigate(`/user/chat?id=${tempThreadId}`);
+            }
+
+            toast.success('New thread added successfully!');
+        } catch (error) {
+            alert('Error adding new thread: ' + error);
+        } finally {
+            setIsAddThreadLoading(false);
+        }
+    };
+
+    return (
+        <button
+            type="button"
+            onClick={() => addNewThread()}
+            onMouseEnter={prefetchChatRouteChunk}
+            onFocus={prefetchChatRouteChunk}
+            disabled={isAddThreadLoading}
+            className={chipAction}
+        >
+            <LucidePlus className="h-3.5 w-3.5" strokeWidth={2} />
+            AI chat
+        </button>
+    );
+};
+
+export default ComponentQuickActionAiChat;

--- a/src/pages/user/userhomepage/ComponentQuickActions.tsx
+++ b/src/pages/user/userhomepage/ComponentQuickActions.tsx
@@ -4,7 +4,6 @@ import {
     LucideChevronDown,
     LucideFileText,
     LucideListTodo,
-    LucidePlus,
     LucideBookOpen,
     LucideHeart,
     LucideCalendar,
@@ -19,6 +18,7 @@ import { infoVaultAddAxios } from '../features/InfoVault/utils/infoVaultListAxio
 import { lifeEventAddAxios } from '../features/LifeEventsList/utils/lifeEventsListAxios';
 import toast from 'react-hot-toast';
 import axiosCustom from '../../../config/axiosCustom';
+import ComponentQuickActionAiChat from './ComponentQuickActionAiChat';
 
 const panel =
     'rounded-2xl border-2 border-sky-200/80 bg-white/90 p-2.5 shadow-md shadow-sky-200/25 backdrop-blur-sm transition hover:shadow-lg hover:shadow-sky-200/40';
@@ -31,7 +31,6 @@ const chipAction =
 
 const QuickActionsComponent = () => {
     const [isActionsExpanded, setIsActionsExpanded] = useState(true);
-    const [isAddThreadLoading, setIsAddThreadLoading] = useState(false);
 
     const navigate = useNavigate();
 
@@ -52,46 +51,6 @@ const QuickActionsComponent = () => {
             navigate(`/user/task?workspace=${result.workspaceId}&edit-task-id=${result.recordId}`);
         } else {
             toast.error(result.error);
-        }
-    };
-
-    const addNewThread = async () => {
-        setIsAddThreadLoading(true);
-        try {
-            let aiModelProvider: 'openrouter' | 'groq' | 'ollama' | 'openai-compatible' = 'openrouter';
-            let aiModelName = 'openrouter/auto';
-            let aiModelOpenAiCompatibleConfigId: string | null = null;
-
-            try {
-                const lastUsedResponse = await axiosCustom.get('/api/chat-llm/threads-crud/lastUsedLlmModel');
-                if (lastUsedResponse.data.model) {
-                    aiModelProvider = lastUsedResponse.data.model.aiModelProvider;
-                    aiModelName = lastUsedResponse.data.model.aiModelName;
-                    aiModelOpenAiCompatibleConfigId =
-                        lastUsedResponse.data.model.aiModelOpenAiCompatibleConfigId || null;
-                }
-            } catch (error) {
-                console.error('Error fetching last used model:', error);
-            }
-
-            const result = await axiosCustom.post('/api/chat-llm/threads-crud/threadsAdd', {
-                isPersonalContextEnabled: false,
-                isAutoAiContextSelectEnabled: false,
-                aiModelProvider: aiModelProvider,
-                aiModelName: aiModelName,
-                aiModelOpenAiCompatibleConfigId: aiModelOpenAiCompatibleConfigId,
-            });
-
-            const tempThreadId = result?.data?.thread?._id;
-            if (tempThreadId && typeof tempThreadId === 'string') {
-                navigate(`/user/chat?id=${tempThreadId}`);
-            }
-
-            toast.success('New thread added successfully!');
-        } catch (error) {
-            alert('Error adding new thread: ' + error);
-        } finally {
-            setIsAddThreadLoading(false);
         }
     };
 
@@ -283,17 +242,8 @@ const QuickActionsComponent = () => {
                 </button>
             </div>
 
-            {isActionsExpanded && (
-                <div className="flex flex-wrap gap-1.5">
-                    <button
-                        type="button"
-                        onClick={() => addNewThread()}
-                        disabled={isAddThreadLoading}
-                        className={chipAction}
-                    >
-                        <LucidePlus className="h-3.5 w-3.5" strokeWidth={2} />
-                        AI chat
-                    </button>
+            <div className={`flex flex-wrap gap-1.5 ${isActionsExpanded ? '' : 'hidden'}`}>
+                    <ComponentQuickActionAiChat />
                     <button
                         type="button"
                         onClick={() => notesQuickDailyNotesAddAxiosLocal()}
@@ -335,7 +285,6 @@ const QuickActionsComponent = () => {
                         About today
                     </button>
                 </div>
-            )}
         </div>
     );
 };


### PR DESCRIPTION
- Introduced `ComponentQuickActionAiChat` for adding new AI chat threads, encapsulating the logic for fetching the last used model and handling thread creation.
- Integrated the new component into `ComponentQuickActions`, replacing the previous inline button implementation for better modularity and code organization.
- Removed redundant thread creation logic from `ComponentQuickActions` to streamline the component's responsibilities.